### PR TITLE
Housekeeping

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -23,16 +23,48 @@ return (new PhpCsFixer\Config('GeckoPackagesCS'))
     ->setRules([
         '@Symfony' => true,
         '@Symfony:risky' => true,
-        'array_syntax' => ['syntax' => 'long'],
-        'class_definition' => ['singleItemSingleLine' => true, 'multiLineExtendsEachSingleLine' => true],
+        'array_syntax' => [
+            'syntax' => 'long'
+        ],
+        'blank_line_before_statement' => [
+            'statements' => [
+                'break',
+                'continue',
+                'return',
+                'throw',
+            ]
+        ],
+        'class_definition' => [
+            'singleItemSingleLine' => true,
+            'multiLineExtendsEachSingleLine' => true
+        ],
         'combine_consecutive_unsets' => true,
         'dir_constant' => true,
         'ereg_to_preg' => true,
-        'header_comment' => ['header' => $header],
+        'header_comment' => [
+            'header' => $header
+        ],
         'heredoc_to_nowdoc' => true,
         'modernize_types_casting' => true,
-        'no_extra_consecutive_blank_lines' => ['break', 'continue', 'curly_brace_block', 'extra', 'parenthesis_brace_block', 'return', 'square_brace_block', 'throw', 'use', 'useTrait'],
+        'no_extra_consecutive_blank_lines' => [
+            'tokens' => [
+                'break',
+                'case',
+                'continue',
+                'curly_brace_block',
+                'default',
+                'extra',
+                'parenthesis_brace_block',
+                'return',
+                'square_brace_block',
+                'switch',
+                'throw',
+                'use',
+                'use_trait',
+            ]
+        ],
         'no_multiline_whitespace_before_semicolons' => false,
+        'no_null_property_initialization' => true,
         'no_php4_constructor' => true,
         'no_short_echo_tag' => true,
         'no_unreachable_default_argument_value' => true,
@@ -42,7 +74,9 @@ return (new PhpCsFixer\Config('GeckoPackagesCS'))
         'ordered_imports' => true,
         'php_unit_fqcn_annotation' => false,
         'php_unit_strict' => true,
-        'phpdoc_add_missing_param_annotation' => ['only_untyped' => false],
+        'phpdoc_add_missing_param_annotation' => [
+            'only_untyped' => false
+        ],
         'phpdoc_order' => true,
         'pow_to_exponentiation' => true,
         'protected_to_private' => true,

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,9 @@ matrix:
         - php: hhvm-nightly
 
 install:
-    - composer update $COMPOSER_FLAGS --no-interaction -v
-    - if [[ $TRAVIS_PHP_VERSION = 7.0 ]]; then curl -L https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.3.2/php-cs-fixer.phar -o php-cs-fixer.phar; fi
+    - travis_retry composer update $COMPOSER_FLAGS --no-interaction -v
+    - composer info -D | sort
+    - if [[ $TRAVIS_PHP_VERSION = 7.0 ]]; then curl -L https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.4.0/php-cs-fixer.phar -o php-cs-fixer.phar; fi
 
 script:
     - chmod 755 tests/assets/dir

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,15 @@
 
 This file contains the changelogs of the package.
 
-### Changelog for v2.1.1
+### Changelog for v2.2
 ###### Pending release
 
-- add missing CHANGELOG.md file
+- Travis - retry composer info, show packages installed
+- Update CS to PHP-CS-Fixer 2.4
+- Better exception messages on construction of `FilePermissionsIsIdenticalConstraint`
+- More strict testing and remove useless escaping
+- Remove dependency on `ctype` extension
+- Add missing CHANGELOG.md file
 
 ### Changelog for v2.1
 ###### Jun 20, 2017

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     },
     "autoload": {
         "psr-4": {
-            "GeckoPackages\\PHPUnit\\": "src\\PHPUnit"
+            "GeckoPackages\\PHPUnit\\": "src/PHPUnit"
         }
     },
     "config": {

--- a/src/PHPUnit/Constraints/FilePermissionsIsIdenticalConstraint.php
+++ b/src/PHPUnit/Constraints/FilePermissionsIsIdenticalConstraint.php
@@ -35,21 +35,22 @@ final class FilePermissionsIsIdenticalConstraint extends \PHPUnit_Framework_Cons
         parent::__construct();
 
         if (is_string($permissions)) {
-            if (!ctype_digit($permissions)) {
-                if (1 !== preg_match(self::$permissionFormat, $permissions)) {
-                    throw new \InvalidArgumentException(sprintf('Permission to match "%s" is not formatted correctly.', $permissions));
-                }
+            if (preg_match('#^\d+$#', $permissions)) {
+                $this->permissions = '0' === $permissions[0]
+                    ? intval($permissions, 8)
+                    : (int) $permissions
+                ;
 
+                return;
+            }
+
+            if (1 === preg_match(self::$permissionFormat, $permissions)) {
                 $this->permissions = $permissions;
 
                 return;
             }
 
-            if ('0' === $permissions[0]) {
-                $permissions = intval($permissions, 8);
-            } else {
-                $permissions = (int) $permissions;
-            }
+            throw new \InvalidArgumentException(sprintf('Permission to match "%s" is not formatted correctly.', $permissions));
         }
 
         if (!is_int($permissions)) {
@@ -65,7 +66,7 @@ final class FilePermissionsIsIdenticalConstraint extends \PHPUnit_Framework_Cons
         }
 
         if ($permissions < 0) {
-            throw new \InvalidArgumentException(sprintf('Invalid value for permission to match "%d", expected >= 0.', $permissions));
+            throw new \InvalidArgumentException(sprintf('Invalid value for permission to match "%d", expected int >= 0 or string.', $permissions));
         }
 
         $this->permissions = $permissions;

--- a/tests/PHPUnit/Tests/Asserts/AssertHelperTest.php
+++ b/tests/PHPUnit/Tests/Asserts/AssertHelperTest.php
@@ -25,7 +25,7 @@ final class AssertHelperTest extends AbstractGeckoPHPUnitTest
 
     /**
      * @expectedException PHPUnit_Framework_Exception
-     * @expectedExceptionMessageRegExp #^FileExistsAssertTrait::assertFileExists\(\) Relies on missing method "assertThat".$#
+     * @expectedExceptionMessageRegExp #^FileExistsAssertTrait::assertFileExists\(\) Relies on missing method "assertThat"\.$#
      */
     public function testMissingMethod()
     {

--- a/tests/PHPUnit/Tests/Asserts/FileExistsAssertTraitTest.php
+++ b/tests/PHPUnit/Tests/Asserts/FileExistsAssertTraitTest.php
@@ -62,7 +62,7 @@ final class FileExistsAssertTraitTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException PHPUnit_Framework_Exception
-     * @expectedExceptionMessageRegExp #^Failed asserting that directory\#/.*PHPUnit/tests/PHPUnit/Tests/Asserts is a file.$#
+     * @expectedExceptionMessageRegExp %^Failed asserting that directory#/.*PHPUnit/tests/PHPUnit/Tests/Asserts is a file\.$%
      */
     public function testAssertFileExistsDirectory()
     {
@@ -71,7 +71,7 @@ final class FileExistsAssertTraitTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException PHPUnit_Framework_Exception
-     * @expectedExceptionMessageRegExp /^Failed asserting that integer\#123 is a file.$/
+     * @expectedExceptionMessageRegExp /^Failed asserting that integer\#123 is a file\.$/
      */
     public function testAssertFileExistsInt()
     {
@@ -80,7 +80,7 @@ final class FileExistsAssertTraitTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException PHPUnit_Framework_Exception
-     * @expectedExceptionMessageRegExp /^Failed asserting that _no_file_ is a file.$/
+     * @expectedExceptionMessageRegExp /^Failed asserting that _no_file_ is a file\.$/
      */
     public function testAssertFileExistsNoFile()
     {
@@ -89,7 +89,7 @@ final class FileExistsAssertTraitTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException PHPUnit_Framework_Exception
-     * @expectedExceptionMessageRegExp /^Failed asserting that null is a file.$/
+     * @expectedExceptionMessageRegExp /^Failed asserting that null is a file\.$/
      */
     public function testAssertFileExistsNull()
     {
@@ -98,7 +98,7 @@ final class FileExistsAssertTraitTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException PHPUnit_Framework_Exception
-     * @expectedExceptionMessageRegExp /^Failed asserting that stdClass\# is a file.$/
+     * @expectedExceptionMessageRegExp /^Failed asserting that stdClass\# is a file\.$/
      */
     public function testAssertFileExistsObject()
     {

--- a/tests/PHPUnit/Tests/Asserts/FileSystemAssertTraitTest.php
+++ b/tests/PHPUnit/Tests/Asserts/FileSystemAssertTraitTest.php
@@ -75,7 +75,7 @@ final class FileSystemAssertTraitTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException PHPUnit_Framework_Exception
-     * @expectedExceptionMessageRegExp #^Failed asserting that directory\#/.*tests/assets/dir 0755 permissions are equal to 0644.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that directory\#/.*tests/assets/dir 0755 permissions are equal to 0644\.$#
      */
     public function testAssertFileHasPermissionsFailureDir()
     {
@@ -85,7 +85,7 @@ final class FileSystemAssertTraitTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException PHPUnit_Framework_Exception
-     * @expectedExceptionMessageRegExp #^Failed asserting that file\#/.*tests/assets/dir/test_file.txt 0644 permissions are equal to 0555.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that file\#/.*tests/assets/dir/test_file\.txt 0644 permissions are equal to 0555\.$#
      */
     public function testAssertFileHasPermissionsFailureFile()
     {
@@ -171,7 +171,7 @@ final class FileSystemAssertTraitTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that directory\#/.*tests/assets/dir is an empty directory.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that directory\#/.*tests/assets/dir is an empty directory\.$#
      */
     public function testAssertDirectoryEmptyFail()
     {
@@ -180,7 +180,7 @@ final class FileSystemAssertTraitTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that a/b/c/d is a directory.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that a/b/c/d is a directory\.$#
      */
     public function testAssertDirectoryExistsFail()
     {
@@ -189,7 +189,7 @@ final class FileSystemAssertTraitTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that file\#/.*tests/assets/dir/test_file.txt is a directory.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that file\#/.*tests/assets/dir/test_file.txt is a directory\.$#
      */
     public function testAssertDirectoryExistsFile()
     {
@@ -198,7 +198,7 @@ final class FileSystemAssertTraitTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException PHPUnit_Framework_Exception
-     * @expectedExceptionMessageRegExp #^Failed asserting that null is a directory.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that null is a directory\.$#
      */
     public function testAssertDirectoryExistsFailNull()
     {
@@ -207,7 +207,7 @@ final class FileSystemAssertTraitTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that file\#/.*tests/assets/dir/test_file.txt is a link.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that file\#/.*tests/assets/dir/test_file.txt is a link\.$#
      */
     public function testAssertFileIsLinkFailFile()
     {
@@ -216,7 +216,7 @@ final class FileSystemAssertTraitTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that directory\#/.*tests/assets/dir is a link.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that directory\#/.*tests/assets/dir is a link\.$#
      */
     public function testAssertFileIsLinkFailDirectory()
     {
@@ -225,7 +225,7 @@ final class FileSystemAssertTraitTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException PHPUnit_Framework_Exception
-     * @expectedExceptionMessageRegExp #^Failed asserting that integer\#678 is a link.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that integer\#678 is a link\.$#
      */
     public function testAssertFileIsLinkFailInteger()
     {
@@ -234,7 +234,7 @@ final class FileSystemAssertTraitTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException PHPUnit_Framework_Exception
-     * @expectedExceptionMessageRegExp #^Argument \#1 \(null\) of FileSystemAssertTrait::assertFileHasPermissions\(\) must be an int \(>= 0\) or string.$#
+     * @expectedExceptionMessageRegExp #^Argument \#1 \(null\) of FileSystemAssertTrait::assertFileHasPermissions\(\) must be an int \(>= 0\) or string\.$#
      */
     public function testAssertFileHasPermissionsFailNull()
     {
@@ -243,7 +243,7 @@ final class FileSystemAssertTraitTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException PHPUnit_Framework_Exception
-     * @expectedExceptionMessageRegExp #^Argument \#1 \(stdClass\#\) of FileSystemAssertTrait::assertFileHasPermissions\(\) must be an int \(>= 0\) or string.$#
+     * @expectedExceptionMessageRegExp #^Argument \#1 \(stdClass\#\) of FileSystemAssertTrait::assertFileHasPermissions\(\) must be an int \(>= 0\) or string\.$#
      */
     public function testAssertFileHasPermissionsFailObject()
     {
@@ -252,7 +252,7 @@ final class FileSystemAssertTraitTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException PHPUnit_Framework_Exception
-     * @expectedExceptionMessageRegExp #^FileSystemAssertTrait::assertFileHasPermissions\(\) Permission to match "invalidrwx" is not formatted correctly.$#
+     * @expectedExceptionMessageRegExp #^FileSystemAssertTrait::assertFileHasPermissions\(\) Permission to match "invalidrwx" is not formatted correctly\.$#
      */
     public function testAssertFileHasPermissionsFailInvalidPermissionString()
     {
@@ -261,7 +261,7 @@ final class FileSystemAssertTraitTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException PHPUnit_Framework_Exception
-     * @expectedExceptionMessageRegExp #^Argument \#1 \(integer\#-1\) of FileSystemAssertTrait::assertFileHasPermissions\(\) must be an int \(>= 0\) or string.$#
+     * @expectedExceptionMessageRegExp #^Argument \#1 \(integer\#-1\) of FileSystemAssertTrait::assertFileHasPermissions\(\) must be an int \(>= 0\) or string\.$#
      */
     public function testAssertFileHasPermissionsFailInvalidPermissionValue()
     {
@@ -280,7 +280,7 @@ final class FileSystemAssertTraitTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException PHPUnit_Framework_Exception
-     * @expectedExceptionMessageRegExp #^Failed asserting that file\#/.*tests/assets/dir/test_file.txt 100644 permissions matches mask 777.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that file\#/.*tests/assets/dir/test_file\.txt 100644 permissions matches mask 777\.$#
      */
     public function testAssertFilePermissionMaskFail()
     {
@@ -290,7 +290,7 @@ final class FileSystemAssertTraitTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException PHPUnit_Framework_Exception
-     * @expectedExceptionMessageRegExp #^Failed asserting that directory\#/.*tests/assets/dir 40755 permissions does not match mask 755.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that directory\#/.*tests/assets/dir 40755 permissions does not match mask 755\.$#
      */
     public function testAssertFilePermissionNotMaskFail()
     {
@@ -300,7 +300,7 @@ final class FileSystemAssertTraitTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException PHPUnit_Framework_Exception
-     * @expectedExceptionMessageRegExp #^Argument \#1 \(null\) of FileSystemAssertTrait::assertFilePermissionMask\(\) must be an int.$#
+     * @expectedExceptionMessageRegExp #^Argument \#1 \(null\) of FileSystemAssertTrait::assertFilePermissionMask\(\) must be an int\.$#
      */
     public function testAssertFilePermissionMaskInvalidArg1()
     {
@@ -310,7 +310,7 @@ final class FileSystemAssertTraitTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException PHPUnit_Framework_Exception
-     * @expectedExceptionMessageRegExp #^Failed asserting that integer\#89 permissions matches mask.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that integer\#89 permissions matches mask\.$#
      */
     public function testAssertFilePermissionMaskInvalidArg2()
     {
@@ -319,7 +319,7 @@ final class FileSystemAssertTraitTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException PHPUnit_Framework_Exception
-     * @expectedExceptionMessageRegExp #^Failed asserting that not file or directory\#no_file permissions matches mask.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that not file or directory\#no_file permissions matches mask\.$#
      */
     public function testAssertFilePermissionMaskInvalidArg2File()
     {

--- a/tests/PHPUnit/Tests/Asserts/RangeAssertTraitTest.php
+++ b/tests/PHPUnit/Tests/Asserts/RangeAssertTraitTest.php
@@ -29,7 +29,7 @@ final class RangeAssertTraitTest extends GeckoTestCase
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that -0.500 is within range \(1.100, 3.200\).$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that -0\.500 is within range \(1.100, 3.200\)\.$#
      */
     public function testAssertNumberInRangeFail()
     {
@@ -43,7 +43,7 @@ final class RangeAssertTraitTest extends GeckoTestCase
 
     /**
      * @expectedException PHPUnit_Framework_Exception
-     * @expectedExceptionMessageRegExp #^Argument \#1 \(null\) of RangeAssertTrait::assertNumberNotInRange\(\) must be a float or int.$#
+     * @expectedExceptionMessageRegExp #^Argument \#1 \(null\) of RangeAssertTrait::assertNumberNotInRange\(\) must be a float or int\.$#
      */
     public function testAssertNumberNotInRangeInvalidArgumentLower()
     {
@@ -52,7 +52,7 @@ final class RangeAssertTraitTest extends GeckoTestCase
 
     /**
      * @expectedException PHPUnit_Framework_Exception
-     * @expectedExceptionMessageRegExp #^Argument \#2 \(string\#_invalid_\) of RangeAssertTrait::assertNumberNotInRange\(\) must be a float or int.$#
+     * @expectedExceptionMessageRegExp #^Argument \#2 \(string\#_invalid_\) of RangeAssertTrait::assertNumberNotInRange\(\) must be a float or int\.$#
      */
     public function testAssertNumberNotInRangeInvalidArgumentUpper()
     {
@@ -71,7 +71,7 @@ final class RangeAssertTraitTest extends GeckoTestCase
 
     /**
      * @expectedException PHPUnit_Framework_Exception
-     * @expectedExceptionMessageRegExp #^RangeAssertTrait::assertNumberOnRange\(\) lower boundary 5 must be smaller than upper boundary -5.500.$#
+     * @expectedExceptionMessageRegExp #^RangeAssertTrait::assertNumberOnRange\(\) lower boundary 5 must be smaller than upper boundary -5\.500\.$#
      */
     public function testAssertNumberOnRangeInvalidRange()
     {
@@ -85,7 +85,7 @@ final class RangeAssertTraitTest extends GeckoTestCase
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that -4 is unsigned int.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that -4 is unsigned int\.$#
      */
     public function testAssertUnsignedIntFail()
     {

--- a/tests/PHPUnit/Tests/Asserts/ScalarAssertTraitTest.php
+++ b/tests/PHPUnit/Tests/Asserts/ScalarAssertTraitTest.php
@@ -34,7 +34,7 @@ final class ScalarAssertTraitTest extends GeckoTestCase
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that DateTime\# is of type bool.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that DateTime\# is of type bool\.$#
      */
     public function testAssertBoolFail()
     {
@@ -53,7 +53,7 @@ final class ScalarAssertTraitTest extends GeckoTestCase
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that double\#1 is of type int.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that double\#1 is of type int\.$#
      */
     public function testAssertIntFail()
     {

--- a/tests/PHPUnit/Tests/Asserts/StringsAssertTraitTest.php
+++ b/tests/PHPUnit/Tests/Asserts/StringsAssertTraitTest.php
@@ -29,7 +29,7 @@ final class StringsAssertTraitTest extends AbstractGeckoPHPUnitTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that two strings are not identical.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that two strings are not identical\.$#
      */
     public function testAssertNotSameStringsFail()
     {
@@ -43,7 +43,7 @@ final class StringsAssertTraitTest extends AbstractGeckoPHPUnitTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that two strings are identical.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that two strings are identical\.$#
      */
     public function testAssertSameStringsFail()
     {
@@ -57,7 +57,7 @@ final class StringsAssertTraitTest extends AbstractGeckoPHPUnitTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that a string is empty.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that a string is empty\.$#
      */
     public function testAssertStringIsEmptyFail()
     {
@@ -71,7 +71,7 @@ final class StringsAssertTraitTest extends AbstractGeckoPHPUnitTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that a string is not empty.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that a string is not empty\.$#
      */
     public function testAssertStringIsNotEmptyFail()
     {
@@ -85,7 +85,7 @@ final class StringsAssertTraitTest extends AbstractGeckoPHPUnitTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that a string is not empty.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that a string is not empty\.$#
      */
     public function testAssertStringIsNotWhiteSpaceFail()
     {
@@ -99,7 +99,7 @@ final class StringsAssertTraitTest extends AbstractGeckoPHPUnitTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that a string is empty.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that a string is empty\.$#
      */
     public function testAssertStringIsWhiteSpaceFail()
     {

--- a/tests/PHPUnit/Tests/Asserts/XMLAssertTraitTest.php
+++ b/tests/PHPUnit/Tests/Asserts/XMLAssertTraitTest.php
@@ -29,7 +29,7 @@ final class XMLAssertTraitTest extends AbstractGeckoPHPUnitTest
 
     /**
      * @expectedException PHPUnit_Framework_Exception
-     * @expectedExceptionMessageRegExp #^Failed asserting that <note><test>Test</test></note> matches XSD.[\n]\[error 1845\] .+.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that <note><test>Test</test></note> matches XSD\.[\n]\[error 1845\] .+\.$#
      */
     public function testAssertXMLMatchesXSDFail()
     {
@@ -47,7 +47,7 @@ final class XMLAssertTraitTest extends AbstractGeckoPHPUnitTest
 
     /**
      * @expectedException PHPUnit_Framework_Exception
-     * @expectedExceptionMessageRegExp /^Argument #1 \(integer#1\) of XMLAssertTrait::assertXMLMatchesXSD\(\) must be a string.$/
+     * @expectedExceptionMessageRegExp /^Argument #1 \(integer#1\) of XMLAssertTrait::assertXMLMatchesXSD\(\) must be a string\.$/
      */
     public function testAssertXMLMatchesXSDInvalidInputXSD()
     {
@@ -56,7 +56,7 @@ final class XMLAssertTraitTest extends AbstractGeckoPHPUnitTest
 
     /**
      * @expectedException PHPUnit_Framework_Exception
-     * @expectedExceptionMessageRegExp #^Failed asserting that b matches XSD.[\n]\[fatal 4\] .+.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that b matches XSD.[\n]\[fatal 4\] .+\.$#
      */
     public function testAssertXMLMatchesXSDInvalidXMLInvalidXSD()
     {
@@ -70,7 +70,7 @@ final class XMLAssertTraitTest extends AbstractGeckoPHPUnitTest
 
     /**
      * @expectedException PHPUnit_Framework_Exception
-     * @expectedExceptionMessageRegExp #^Failed asserting that test string is valid XML.[\n]\[fatal 4\] .+.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that test string is valid XML.[\n]\[fatal 4\] .+\.$#
      */
     public function testAssertXMLValidFail()
     {
@@ -79,7 +79,7 @@ final class XMLAssertTraitTest extends AbstractGeckoPHPUnitTest
 
     /**
      * @expectedException PHPUnit_Framework_Exception
-     * @expectedExceptionMessageRegExp /^Failed asserting that integer\#1234 is valid XML.$/
+     * @expectedExceptionMessageRegExp /^Failed asserting that integer\#1234 is valid XML\.$/
      */
     public function testAssertXMLValidInvalidInput()
     {

--- a/tests/PHPUnit/Tests/Constraints/DirectoryEmptyConstraintTest.php
+++ b/tests/PHPUnit/Tests/Constraints/DirectoryEmptyConstraintTest.php
@@ -40,7 +40,7 @@ final class DirectoryEmptyConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that directory\#/.*PHPUnit/tests/PHPUnit/Tests/Constraints is an empty directory.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that directory\#/.*PHPUnit/tests/PHPUnit/Tests/Constraints is an empty directory\.$#
      */
     public function testDirectoryEmptyConstraintDirWithFiles()
     {
@@ -50,7 +50,7 @@ final class DirectoryEmptyConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that file\#/.*PHPUnit/tests/PHPUnit/Tests/Constraints/DirectoryEmptyConstraintTest.php is an empty directory.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that file\#/.*PHPUnit/tests/PHPUnit/Tests/Constraints/DirectoryEmptyConstraintTest.php is an empty directory\.$#
      */
     public function testDirectoryEmptyConstraintFile()
     {
@@ -60,7 +60,7 @@ final class DirectoryEmptyConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that link to file\#/.*test_link_file is an empty directory.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that link to file\#/.*test_link_file is an empty directory\.$#
      */
     public function testDirectoryEmptyConstraintFileLink()
     {
@@ -76,7 +76,7 @@ final class DirectoryEmptyConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that integer\#1 is an empty directory.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that integer\#1 is an empty directory\.$#
      */
     public function testDirectoryEmptyConstraintInt()
     {
@@ -86,7 +86,7 @@ final class DirectoryEmptyConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that null is an empty directory.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that null is an empty directory\.$#
      */
     public function testDirectoryEmptyConstraintNull()
     {
@@ -96,7 +96,7 @@ final class DirectoryEmptyConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that stdClass\# is an empty directory.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that stdClass\# is an empty directory\.$#
      */
     public function testDirectoryEmptyConstraintObject()
     {
@@ -106,7 +106,7 @@ final class DirectoryEmptyConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that __does_not_exists__ is an empty directory.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that __does_not_exists__ is an empty directory\.$#
      */
     public function testDirectoryEmptyConstraintString()
     {

--- a/tests/PHPUnit/Tests/Constraints/DirectoryExistsConstraintTest.php
+++ b/tests/PHPUnit/Tests/Constraints/DirectoryExistsConstraintTest.php
@@ -52,7 +52,7 @@ final class DirectoryExistsConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that file\#/.*PHPUnit/tests/PHPUnit/Tests/Constraints/DirectoryExistsConstraintTest.php is a directory.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that file\#/.*PHPUnit/tests/PHPUnit/Tests/Constraints/DirectoryExistsConstraintTest.php is a directory\.$#
      */
     public function testDirectoryExistsConstraintFile()
     {
@@ -62,7 +62,7 @@ final class DirectoryExistsConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that link to file\#/.*test_link_file is a directory.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that link to file\#/.*test_link_file is a directory\.$#
      */
     public function testDirectoryExistsConstraintFileLink()
     {
@@ -78,7 +78,7 @@ final class DirectoryExistsConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that integer\#1 is a directory.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that integer\#1 is a directory\.$#
      */
     public function testDirectoryExistsConstraintInt()
     {
@@ -88,7 +88,7 @@ final class DirectoryExistsConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that null is a directory.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that null is a directory\.$#
      */
     public function testDirectoryExistsConstraintNull()
     {
@@ -98,7 +98,7 @@ final class DirectoryExistsConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that stdClass\# is a directory.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that stdClass\# is a directory\.$#
      */
     public function testDirectoryExistsConstraintObject()
     {
@@ -108,7 +108,7 @@ final class DirectoryExistsConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that __does_not_exists__ is a directory.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that __does_not_exists__ is a directory\.$#
      */
     public function testDirectoryExistsConstraintString()
     {

--- a/tests/PHPUnit/Tests/Constraints/FileExistsConstraintTest.php
+++ b/tests/PHPUnit/Tests/Constraints/FileExistsConstraintTest.php
@@ -52,7 +52,7 @@ final class FileExistsConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that directory\#/.*PHPUnit/tests/PHPUnit/Tests/Constraints is a file.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that directory\#/.*PHPUnit/tests/PHPUnit/Tests/Constraints is a file\.$#
      */
     public function testFileExistsConstraintDir()
     {
@@ -62,7 +62,7 @@ final class FileExistsConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that link to directory\#/.*test_link_dir is a file.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that link to directory\#/.*test_link_dir is a file\.$#
      */
     public function testFileExistsConstraintFileLink()
     {
@@ -78,7 +78,7 @@ final class FileExistsConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that integer\#1 is a file.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that integer\#1 is a file\.$#
      */
     public function testFileExistsConstraintInt()
     {
@@ -88,7 +88,7 @@ final class FileExistsConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that null is a file.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that null is a file\.$#
      */
     public function testFileExistsConstraintNull()
     {
@@ -98,7 +98,7 @@ final class FileExistsConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that stdClass\# is a file.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that stdClass\# is a file\.$#
      */
     public function testFileExistsConstraintObject()
     {
@@ -108,7 +108,7 @@ final class FileExistsConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that __does_not_exists__ is a file.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that __does_not_exists__ is a file\.$#
      */
     public function testFileExistsConstraintString()
     {

--- a/tests/PHPUnit/Tests/Constraints/FileIsLinkConstraintTest.php
+++ b/tests/PHPUnit/Tests/Constraints/FileIsLinkConstraintTest.php
@@ -58,7 +58,7 @@ final class FileIsLinkConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that directory\#/.*PHPUnit/tests/PHPUnit/Tests/Constraints is a link.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that directory\#/.*PHPUnit/tests/PHPUnit/Tests/Constraints is a link\.$#
      */
     public function testFileIsLinkConstraintDir()
     {
@@ -68,7 +68,7 @@ final class FileIsLinkConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that file\#/.*PHPUnit/tests/PHPUnit/Tests/Constraints/FileIsLinkConstraintTest.php is a link.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that file\#/.*PHPUnit/tests/PHPUnit/Tests/Constraints/FileIsLinkConstraintTest.php is a link\.$#
      */
     public function testFileIsLinkConstraintFile()
     {
@@ -78,7 +78,7 @@ final class FileIsLinkConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that integer\#1 is a link.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that integer\#1 is a link\.$#
      */
     public function testFileIsLinkConstraintInt()
     {
@@ -88,7 +88,7 @@ final class FileIsLinkConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that null is a link.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that null is a link\.$#
      */
     public function testFileIsLinkConstraintNull()
     {
@@ -98,7 +98,7 @@ final class FileIsLinkConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that stdClass\# is a link.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that stdClass\# is a link\.$#
      */
     public function testFileIsLinkConstraintObject()
     {
@@ -108,7 +108,7 @@ final class FileIsLinkConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that __does_not_exists__ is a link.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that __does_not_exists__ is a link\.$#
      */
     public function testFileIsLinkConstraintString()
     {

--- a/tests/PHPUnit/Tests/Constraints/FileIsValidLinkConstraintTest.php
+++ b/tests/PHPUnit/Tests/Constraints/FileIsValidLinkConstraintTest.php
@@ -44,7 +44,7 @@ final class FileIsValidLinkConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that link\#/.*tests/assets/invalid_link is a valid link.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that link\#/.*tests/assets/invalid_link is a valid link\.$#
      */
     public function testFileIsValidLinkToNowhere()
     {
@@ -54,7 +54,7 @@ final class FileIsValidLinkConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that stdClass\# is a valid link.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that stdClass\# is a valid link\.$#
      */
     public function testFileIsValidLinkObject()
     {
@@ -64,7 +64,7 @@ final class FileIsValidLinkConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that null is a valid link.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that null is a valid link\.$#
      */
     public function testFileIsValidLinkNull()
     {
@@ -74,7 +74,7 @@ final class FileIsValidLinkConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that string\#a is a valid link.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that string\#a is a valid link\.$#
      */
     public function testFileIsValidLinkString()
     {
@@ -84,7 +84,7 @@ final class FileIsValidLinkConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that integer\#1 is a valid link.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that integer\#1 is a valid link\.$#
      */
     public function testFileIsValidLinkNotString()
     {
@@ -94,7 +94,7 @@ final class FileIsValidLinkConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that file\#/.*tests/assets/dir/test_file.txt is a valid link.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that file\#/.*tests/assets/dir/test_file.txt is a valid link\.$#
      */
     public function testFileIsValidLinkFile()
     {
@@ -104,7 +104,7 @@ final class FileIsValidLinkConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that directory\#/.*tests/assets/ is a valid link.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that directory\#/.*tests/assets/ is a valid link\.$#
      */
     public function testFileIsValidLinkDir()
     {

--- a/tests/PHPUnit/Tests/Constraints/FilePermissionsIsIdenticalConstraintTest.php
+++ b/tests/PHPUnit/Tests/Constraints/FilePermissionsIsIdenticalConstraintTest.php
@@ -27,7 +27,7 @@ final class FilePermissionsIsIdenticalConstraintTest extends AbstractGeckoPHPUni
     public function testFilePermissionsMaskConstraint($expected, $permission)
     {
         $constraint = new FilePermissionsIsIdenticalConstraint($permission);
-        $this->assertSame($expected, $constraint->evaluate($this->getTestFile(), '', true));
+        $this->assertSame($expected, $constraint->evaluate($this->getTestFile(), '', true), 'Permisson evaluation failed.');
     }
 
     public function providePermissionExpected()
@@ -35,6 +35,7 @@ final class FilePermissionsIsIdenticalConstraintTest extends AbstractGeckoPHPUni
         return array(
             array(true, 100644),
             array(true, '100644'),
+            array(true, 0644),
             array(true, '0644'),
             array(true, '-rw-r--r--'),
         );
@@ -49,7 +50,7 @@ final class FilePermissionsIsIdenticalConstraintTest extends AbstractGeckoPHPUni
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp #^Invalid value for permission to match \"-1\", expected >= 0.$#
+     * @expectedExceptionMessageRegExp #^Invalid value for permission to match "-1", expected int >= 0 or string\.$#
      */
     public function testFilePermissionsMaskConstraintInvalidArg1()
     {
@@ -58,7 +59,7 @@ final class FilePermissionsIsIdenticalConstraintTest extends AbstractGeckoPHPUni
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp #^Permission to match \"invalid"\ is not formatted correctly.$#
+     * @expectedExceptionMessageRegExp #^Permission to match "invalid" is not formatted correctly\.$#
      */
     public function testFilePermissionsMaskConstraintInvalidArg2()
     {
@@ -67,37 +68,61 @@ final class FilePermissionsIsIdenticalConstraintTest extends AbstractGeckoPHPUni
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp #^Invalid value for permission to match \"stdClass\#\", expected int >= 0 or string.$#
+     * @expectedExceptionMessageRegExp #^Invalid value for permission to match "stdClass\#", expected int >= 0 or string\.$#
      */
     public function testFilePermissionsMaskConstraintInvalidArg3()
     {
-        $c = new FilePermissionsIsIdenticalConstraint(new \stdClass());
-        $c->evaluate(1);
+        new FilePermissionsIsIdenticalConstraint(new \stdClass());
     }
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp #^Invalid value for permission to match \"null\", expected int >= 0 or string.$#
+     * @expectedExceptionMessageRegExp #^Invalid value for permission to match "null", expected int >= 0 or string\.$#
      */
     public function testFilePermissionsMaskConstraintInvalidArg4()
     {
-        $c = new FilePermissionsIsIdenticalConstraint(null);
-        $c->evaluate(1);
+        new FilePermissionsIsIdenticalConstraint(null);
     }
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp #^Invalid value for permission to match \"double\#1.5\", expected int >= 0 or string.$#
+     * @expectedExceptionMessageRegExp #^Invalid value for permission to match "double\#1\.5", expected int >= 0 or string\.$#
      */
     public function testFilePermissionsMaskConstraintInvalidArg5()
     {
-        $c = new FilePermissionsIsIdenticalConstraint(1.5);
-        $c->evaluate(1);
+        new FilePermissionsIsIdenticalConstraint(1.5);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessageRegExp #^Permission to match "1\.5" is not formatted correctly\.$#
+     */
+    public function testFilePermissionsMaskConstraintInvalidArg6()
+    {
+        new FilePermissionsIsIdenticalConstraint('1.5');
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessageRegExp #^Permission to match "1,5" is not formatted correctly\.$#
+     */
+    public function testFilePermissionsMaskConstraintInvalidArg7()
+    {
+        new FilePermissionsIsIdenticalConstraint('1,5');
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessageRegExp #^Permission to match "-1" is not formatted correctly\.$#
+     */
+    public function testFilePermissionsMaskConstraintInvalidArg8()
+    {
+        new FilePermissionsIsIdenticalConstraint('-1');
     }
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that integer\#1 permissions are equal.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that integer\#1 permissions are equal\.$#
      */
     public function testFilePermissionsMaskConstraintInt()
     {
@@ -107,7 +132,7 @@ final class FilePermissionsIsIdenticalConstraintTest extends AbstractGeckoPHPUni
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that not file or directory\#_does_not_exists_ permissions are equal.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that not file or directory\#_does_not_exists_ permissions are equal\.$#
      */
     public function testFilePermissionsMaskConstraintNoFile()
     {
@@ -117,7 +142,7 @@ final class FilePermissionsIsIdenticalConstraintTest extends AbstractGeckoPHPUni
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that null permissions are equal.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that null permissions are equal\.$#
      */
     public function testFilePermissionsMaskConstraintNull()
     {
@@ -127,7 +152,7 @@ final class FilePermissionsIsIdenticalConstraintTest extends AbstractGeckoPHPUni
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that stdClass\# permissions are equal.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that stdClass\# permissions are equal\.$#
      */
     public function testFilePermissionsMaskConstraintObject()
     {
@@ -149,7 +174,7 @@ final class FilePermissionsIsIdenticalConstraintTest extends AbstractGeckoPHPUni
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that link\#/.*PHPUnit/tests/assets/test_link_file 0777 permissions are equal to 0111.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that link\#/.*PHPUnit/tests/assets/test_link_file 0777 permissions are equal to 0111\.$#
      */
     public function testFilePermissionsMaskConstraintFileLinkMismatch()
     {
@@ -165,7 +190,7 @@ final class FilePermissionsIsIdenticalConstraintTest extends AbstractGeckoPHPUni
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that file\#/.*tests/assets/dir/test_file.txt 0644 permissions are equal to 0111.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that file\#/.*tests/assets/dir/test_file.txt 0644 permissions are equal to 0111\.$#
      */
     public function testFilePermissionsMaskConstraintFileMismatch()
     {
@@ -175,7 +200,7 @@ final class FilePermissionsIsIdenticalConstraintTest extends AbstractGeckoPHPUni
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that file\#/.*tests/assets/dir/test_file.txt 0100644 permissions are equal to 0100775.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that file\#/.*tests/assets/dir/test_file.txt 0100644 permissions are equal to 0100775\.$#
      */
     public function testFilePermissionsMaskConstraintFileMismatchLarge()
     {
@@ -185,7 +210,7 @@ final class FilePermissionsIsIdenticalConstraintTest extends AbstractGeckoPHPUni
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that file\#/.*tests/assets/dir/test_file.txt -rw-r--r-- permissions are equal to -rw-rw-rw-.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that file\#/.*tests/assets/dir/test_file.txt -rw-r--r-- permissions are equal to -rw-rw-rw-\.$#
      */
     public function testFilePermissionsMaskConstraintFileMismatchString()
     {

--- a/tests/PHPUnit/Tests/Constraints/FilePermissionsMaskConstraintTest.php
+++ b/tests/PHPUnit/Tests/Constraints/FilePermissionsMaskConstraintTest.php
@@ -52,7 +52,7 @@ final class FilePermissionsMaskConstraintTest extends AbstractGeckoPHPUnitFileTe
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that boolean\# permissions matches mask.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that boolean\# permissions matches mask\.$#
      */
     public function testFilePermissionsMaskConstraintFalse()
     {
@@ -74,7 +74,7 @@ final class FilePermissionsMaskConstraintTest extends AbstractGeckoPHPUnitFileTe
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that not file or directory\#_does_not_exists_ permissions matches mask.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that not file or directory\#_does_not_exists_ permissions matches mask\.$#
      */
     public function testFilePermissionsMaskConstraintFileNotExists()
     {
@@ -84,7 +84,7 @@ final class FilePermissionsMaskConstraintTest extends AbstractGeckoPHPUnitFileTe
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that integer\#1443 permissions matches mask.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that integer\#1443 permissions matches mask\.$#
      */
     public function testFilePermissionsMaskConstraintInt()
     {
@@ -94,7 +94,7 @@ final class FilePermissionsMaskConstraintTest extends AbstractGeckoPHPUnitFileTe
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that file\#/.*tests/assets/dir/test_file.txt 100644 permissions matches mask 777.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that file\#/.*tests/assets/dir/test_file.txt 100644 permissions matches mask 777\.$#
      */
     public function testFilePermissionsMaskConstraintMaskMismatch()
     {
@@ -104,7 +104,7 @@ final class FilePermissionsMaskConstraintTest extends AbstractGeckoPHPUnitFileTe
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that null permissions matches mask.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that null permissions matches mask\.$#
      */
     public function testFilePermissionsMaskConstraintNull()
     {
@@ -114,7 +114,7 @@ final class FilePermissionsMaskConstraintTest extends AbstractGeckoPHPUnitFileTe
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that stdClass\# permissions matches mask.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that stdClass\# permissions matches mask\.$#
      */
     public function testFilePermissionsMaskConstraintObject()
     {

--- a/tests/PHPUnit/Tests/Constraints/NumberRangeConstraintTest.php
+++ b/tests/PHPUnit/Tests/Constraints/NumberRangeConstraintTest.php
@@ -46,7 +46,7 @@ final class NumberRangeConstraintTest extends AbstractGeckoPHPUnitTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that 1 is within range \(0, 1\).$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that 1 is within range \(0, 1\)\.$#
      */
     public function testNumberRangeConstraintFailOnRange()
     {
@@ -57,7 +57,7 @@ final class NumberRangeConstraintTest extends AbstractGeckoPHPUnitTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that 2.500 is in range \[0.500, 1.500\].$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that 2.500 is in range \[0\.500, 1\.500\]\.$#
      */
     public function testNumberRangeConstraintFailOutOfRange()
     {

--- a/tests/PHPUnit/Tests/Constraints/ScalarConstraintTest.php
+++ b/tests/PHPUnit/Tests/Constraints/ScalarConstraintTest.php
@@ -20,7 +20,7 @@ final class ScalarConstraintTest extends AbstractGeckoPHPUnitTest
 {
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that integer\#1 is of type array.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that integer\#1 is of type array\.$#
      */
     public function testArray()
     {
@@ -31,7 +31,7 @@ final class ScalarConstraintTest extends AbstractGeckoPHPUnitTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that null is of type bool.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that null is of type bool\.$#
      */
     public function testBool()
     {
@@ -42,7 +42,7 @@ final class ScalarConstraintTest extends AbstractGeckoPHPUnitTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that stdClass\# is of type float.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that stdClass\# is of type float\.$#
      */
     public function testFloat()
     {
@@ -53,7 +53,7 @@ final class ScalarConstraintTest extends AbstractGeckoPHPUnitTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that null is of type int.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that null is of type int\.$#
      */
     public function testInt()
     {
@@ -64,7 +64,7 @@ final class ScalarConstraintTest extends AbstractGeckoPHPUnitTest
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp #^Unknown ScalarConstraint type "null" provided.$#
+     * @expectedExceptionMessageRegExp #^Unknown ScalarConstraint type "null" provided\.$#
      */
     public function testNullType()
     {
@@ -73,7 +73,7 @@ final class ScalarConstraintTest extends AbstractGeckoPHPUnitTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that null is of type string.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that null is of type string\.$#
      */
     public function testString()
     {
@@ -90,7 +90,7 @@ final class ScalarConstraintTest extends AbstractGeckoPHPUnitTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that null is of type scalar.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that null is of type scalar\.$#
      */
     public function testScalar()
     {
@@ -102,7 +102,7 @@ final class ScalarConstraintTest extends AbstractGeckoPHPUnitTest
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp #^Unknown ScalarConstraint type "integer\#123456789" provided.$#
+     * @expectedExceptionMessageRegExp #^Unknown ScalarConstraint type "integer\#123456789" provided\.$#
      */
     public function testUnknownValue()
     {

--- a/tests/PHPUnit/Tests/Constraints/UnsignedIntConstraintTest.php
+++ b/tests/PHPUnit/Tests/Constraints/UnsignedIntConstraintTest.php
@@ -53,7 +53,7 @@ final class UnsignedIntConstraintTest extends AbstractGeckoPHPUnitTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that null is unsigned int.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that null is unsigned int\.$#
      */
     public function testUnsignedIntConstraintFailMessage()
     {

--- a/tests/PHPUnit/Tests/Constraints/XML/XMLMatchesXSDConstraintTest.php
+++ b/tests/PHPUnit/Tests/Constraints/XML/XMLMatchesXSDConstraintTest.php
@@ -33,7 +33,7 @@ final class XMLMatchesXSDConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that boolean\# matches XSD.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that boolean\# matches XSD\.$#
      */
     public function testXMLValidConstraintFalse()
     {
@@ -43,7 +43,7 @@ final class XMLMatchesXSDConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that integer\#1 matches XSD.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that integer\#1 matches XSD\.$#
      */
     public function testXMLValidConstraintInt()
     {
@@ -63,7 +63,7 @@ final class XMLMatchesXSDConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that <a></a> matches XSD.[\n]\[error \d{1,}\](?s).*$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that <a></a> matches XSD.[\n]\[error \d{1,}\](?s).*\.$#
      */
     public function testXMLValidConstraintNotMatchingXML()
     {
@@ -73,7 +73,7 @@ final class XMLMatchesXSDConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that null matches XSD.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that null matches XSD\.$#
      */
     public function testXMLValidConstraintNull()
     {
@@ -83,7 +83,7 @@ final class XMLMatchesXSDConstraintTest extends AbstractGeckoPHPUnitFileTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that stdClass\# matches XSD.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that stdClass\# matches XSD\.$#
      */
     public function testXMLValidConstraintObject()
     {

--- a/tests/PHPUnit/Tests/Constraints/XML/XMLValidConstraintTest.php
+++ b/tests/PHPUnit/Tests/Constraints/XML/XMLValidConstraintTest.php
@@ -33,7 +33,7 @@ final class XMLValidConstraintTest extends AbstractGeckoPHPUnitTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that boolean\# is valid XML.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that boolean\# is valid XML\.$#
      */
     public function testXMLValidConstraintFalse()
     {
@@ -43,7 +43,7 @@ final class XMLValidConstraintTest extends AbstractGeckoPHPUnitTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that integer\#1 is valid XML.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that integer\#1 is valid XML\.$#
      */
     public function testXMLValidConstraintInt()
     {
@@ -63,7 +63,7 @@ final class XMLValidConstraintTest extends AbstractGeckoPHPUnitTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that null is valid XML.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that null is valid XML\.$#
      */
     public function testXMLValidConstraintNull()
     {
@@ -73,7 +73,7 @@ final class XMLValidConstraintTest extends AbstractGeckoPHPUnitTest
 
     /**
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
-     * @expectedExceptionMessageRegExp #^Failed asserting that stdClass\# is valid XML.$#
+     * @expectedExceptionMessageRegExp #^Failed asserting that stdClass\# is valid XML\.$#
      */
     public function testXMLValidConstraintObject()
     {


### PR DESCRIPTION
- update to PHP-CS-Fixer 2.4.0
- drop dependency on `ctype`
- strict testing
- tweaks on check input for file permission constraint