### PR TITLE
Add PHPUnit 7.0 conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": "^7.0"
     },
     "conflict": {
-        "phpunit/phpunit": "<6.0"
+        "phpunit/phpunit": "<6.0 || >6.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0"


### PR DESCRIPTION
Fatal error: Declaration of GeckoPackages\PHPUnit\Constraints\SameStringsConstraint::additionalFailureDescription($other) must be compatible with PHPUnit\Framework\Constraint\Constraint::additionalFailureDescription($other): string in ./vendor/gecko-packages/gecko-php-unit/src/PHPUnit/Constraints/SameStringsConstraint.php on line 43